### PR TITLE
Replace site-admin with superuser

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,9 +8,9 @@ class User < ApplicationRecord
   has_many :memberships, dependent: :destroy
   has_many :roles, through: :memberships
 
-  def site_admin?
-    admin = Role.find_by(name: 'admin')
-    memberships.find_by(role: admin)
+  def superuser?
+    superuser = Role.find_by(name: 'superuser')
+    memberships.find_by(role: superuser)
   end
 
 end

--- a/app/policies/admin_tool_policy.rb
+++ b/app/policies/admin_tool_policy.rb
@@ -1,6 +1,6 @@
 class AdminToolPolicy < Struct.new(:user, :AdminTool)
   def show?
     raise Pundit::NotAuthorizedError, "must be logged in" unless user
-    user.site_admin?
+    user.superuser?
   end
 end

--- a/app/policies/organization_policy.rb
+++ b/app/policies/organization_policy.rb
@@ -1,14 +1,14 @@
 class OrganizationPolicy < ApplicationPolicy
   def create?
-    user.site_admin?
+    user.superuser?
   end
 
   def update?
-    user.site_admin?
+    user.superuser?
   end
 
   def destroy?
-    user.site_admin?
+    user.superuser?
   end
 
 end

--- a/spec/controllers/admin_tools_controller_spec.rb
+++ b/spec/controllers/admin_tools_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe AdminToolsController, type: :controller do
       expect(response).to have_http_status(:success)
     end
 
-    it "redirects for non-admin user" do
+    it "redirects when not a superuser" do
       allow(controller).to receive(:current_user).and_return(user)
       get :show
       expect(response).to have_http_status(:redirect)

--- a/spec/policies/admin_tool_policy_spec.rb
+++ b/spec/policies/admin_tool_policy_spec.rb
@@ -4,22 +4,22 @@ require 'pundit/rspec'
 RSpec.describe AdminToolPolicy, type: :policy do
   subject { described_class }
 
-  Role.create(name: 'admin')
+  Role.create(name: 'superuser')
 
-  admin_role = Role.find_by(name: 'admin')
+  superuser_role = Role.find_by(name: 'superuser')
 
   let(:organization) { create(:organization) }
 
-  let(:admin) { create(:user) }
+  let(:superuser) { create(:user) }
   let(:user) { create(:user, email: 'user_email@example.org') }
 
   permissions :show? do
-    it 'grants access to the site admin' do
-      Membership.create(role_id: admin_role.id, user_id: admin.id)
-      expect(subject).to permit(admin, organization)
+    it 'grants access to the superuser' do
+      Membership.create(role_id: superuser_role.id, user_id: superuser.id)
+      expect(subject).to permit(superuser, organization)
     end
 
-    it 'denies acces to non-admins' do
+    it 'denies acces when not a superuser' do
       expect(subject).to_not permit(user, organization)
     end
   end

--- a/spec/policies/organizations_policy_spec.rb
+++ b/spec/policies/organizations_policy_spec.rb
@@ -4,22 +4,22 @@ require 'pundit/rspec'
 describe OrganizationPolicy do
   subject { described_class }
 
-  Role.create(name: 'admin')
+  Role.create(name: 'superuser')
 
-  admin_role = Role.find_by(name: 'admin')
+  superuser_role = Role.find_by(name: 'superuser')
 
   let(:organization) { create(:organization) }
 
-  let!(:admin) { create(:user) }
+  let!(:superuser) { create(:user) }
   let(:user) { create(:user, email: 'user_email@example.org') }
 
   permissions :new?, :create?, :edit?, :update?, :destroy? do
-    it 'grants access to the site admin' do
-      Membership.create(role_id: admin_role.id, user_id: admin.id)
-      expect(subject).to permit(admin, organization)
+    it 'grants access to the superuser' do
+      Membership.create(role_id: superuser_role.id, user_id: superuser.id)
+      expect(subject).to permit(superuser, organization)
     end
 
-    it 'denies acces to non-admins' do
+    it 'denies acces when not a superuser' do
       expect(subject).to_not permit(user, organization)
     end
   end


### PR DESCRIPTION
This is done to disambiguate the term site-admin vs org-admin.