### PR TITLE
Move user registration to admin page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,11 +1,29 @@
 class UsersController < ApplicationController
-  before_action :set_user, except: :index
+  before_action :set_user, only: [:show, :destroy]
 
   def index
     @users = User.all
   end
 
   def show
+  end
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+
+    respond_to do |format|
+      if @user.save
+        format.html { redirect_to @user, notice: 'User was successfully created.' }
+        format.json { render :show, status: :created, location: @user }
+      else
+        format.html { render :new }
+        format.json { render json: @user.errors, status: :unprocessable_entity }
+      end
+    end
   end
 
   def destroy
@@ -24,6 +42,6 @@ class UsersController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def user_params
-      params.require(:user).permit(:name, :email)
+      params.require(:user).permit(:name, :email, :password)
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,10 @@
 class UsersController < ApplicationController
   before_action :set_user, only: [:show, :destroy]
+  before_action :authorize_user, only: [:show, :destroy]
 
   def index
     @users = User.all
+    authorize @users
   end
 
   def show
@@ -10,10 +12,12 @@ class UsersController < ApplicationController
 
   def new
     @user = User.new
+    authorize @user
   end
 
   def create
     @user = User.new(user_params)
+    authorize @user
 
     respond_to do |format|
       if @user.save
@@ -43,5 +47,9 @@ class UsersController < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def user_params
       params.require(:user).permit(:name, :email, :password)
+    end
+
+    def authorize_user
+      authorize @user
     end
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -11,11 +11,11 @@ class Membership < ApplicationRecord
   private
 
     def superuser_role
-      @superuser_role ||= Role.find_by(name: 'superuser').id
+      @superuser_role ||= Role.find_by(name: 'superuser')
     end
 
     def superuser?
-      role_id == superuser_role
+      role_id == superuser_role.id
     end
 
     def single_role

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,13 +10,11 @@ class User < ApplicationRecord
   has_many :organizations, through: :memberships
 
   def superuser?
-    superuser = Role.find_by(name: 'superuser')
-    memberships.find_by(role: superuser)
+    roles.any? { |role| role.name == 'superuser' }
   end
 
   def admin?
-    admin = Role.find_by(name: 'admin')
-    memberships.find_by(role: admin)
+    roles.any? { |role| role.name == 'admin' }
   end
 
   def admin_for?(record)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,7 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+  devise :database_authenticatable, :recoverable, :rememberable, :validatable
   validates :name, presence: true
   validates :email, uniqueness: true
   has_many :memberships, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,8 @@ class User < ApplicationRecord
   validates :email, uniqueness: true
   has_many :memberships, dependent: :destroy
   has_many :roles, through: :memberships
-  has_one :organization, through: :memberships
+  # has one organization through memberships validations
+  has_many :organizations, through: :memberships
 
   def superuser?
     superuser = Role.find_by(name: 'superuser')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,4 +13,16 @@ class User < ApplicationRecord
     memberships.find_by(role: superuser)
   end
 
+  def admin?
+    admin = Role.find_by(name: 'admin')
+    memberships.find_by(role: admin)
+  end
+
+  def admin_for?(record)
+    admin? && organization == record.organization
+  end
+
+  def organization
+    organizations.first
+  end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -6,6 +6,6 @@ class UserPolicy < ApplicationPolicy
   end
 
   def create?
-    user.superuser?
+    user.superuser? || user.admin?
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -5,6 +5,10 @@ class UserPolicy < ApplicationPolicy
     end
   end
 
+  def index?
+    user.superuser? || user.admin_for?(record)
+  end
+
   def create?
     user.superuser? || user.admin?
   end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -9,6 +9,10 @@ class UserPolicy < ApplicationPolicy
     user.superuser? || user.admin_for?(record)
   end
 
+  def show?
+    true
+  end
+
   def create?
     user.superuser? || user.admin?
   end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,0 +1,11 @@
+class UserPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+
+  def create?
+    user.superuser?
+  end
+end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -16,4 +16,8 @@ class UserPolicy < ApplicationPolicy
   def create?
     user.superuser? || user.admin?
   end
+
+  def destroy?
+    user.superuser? || user.admin_for?(record)
+  end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -6,7 +6,7 @@ class UserPolicy < ApplicationPolicy
   end
 
   def index?
-    user.superuser? || user.admin_for?(record)
+    user.superuser?
   end
 
   def show?

--- a/app/views/admin_tools/show.html.erb
+++ b/app/views/admin_tools/show.html.erb
@@ -1,7 +1,11 @@
 <h1>AdminTools</h1>
 
+<h2>New User</h2>
+
+<%= link_to 'Add User', new_user_path, class: "link hover-blue dib pa2" %>
+
 <h2>New Organization</h2>
 
 <%= render 'organizations/form', organization: @organization %>
 
-<%= link_to "Show All", organizations_path %>
+<%= link_to "Show All", organizations_path, class: "link hover-blue dib pa2" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,7 @@
           <%= link_to 'Home', root_path, class: "link hover-blue dib pa2" %>
           <%= link_to 'Organizations', organizations_path, class: "link hover-blue dib pa2" %>
           <%= link_to 'About', about_path, class: "link hover-blue dib pa2" %>
+          <%= link_to 'Sign in', user_session_path unless current_user %>
           <%= link_to 'Sign Out', destroy_user_session_path, class: "link hover-blue dib pa2", method: :delete if current_user %>
         </div>
       </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,6 @@
           <%= link_to 'Home', root_path, class: "link hover-blue dib pa2" %>
           <%= link_to 'Organizations', organizations_path, class: "link hover-blue dib pa2" %>
           <%= link_to 'About', about_path, class: "link hover-blue dib pa2" %>
-          <%= link_to 'Add User', new_user_registration_path, class: "link hover-blue dib pa2" unless current_user %>
           <%= link_to 'Sign Out', destroy_user_session_path, class: "link hover-blue dib pa2", method: :delete if current_user %>
         </div>
       </div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,0 +1,32 @@
+<%= form_with(model: user, local: true) do |form| %>
+  <% if user.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(user.errors.count, "error") %> prohibited this user from being saved:</h2>
+
+      <ul>
+        <% user.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :name %>
+    <%= form.text_field :name %>
+  </div>
+
+  <div class="field">
+    <%= form.label :email %>
+    <%= form.text_field :email %>
+  </div>
+
+  <div class="field">
+    <%= form.label :password %>
+    <%= form.password_field :password %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,3 @@
+<h1>New User</h1>
+
+<%= render 'form', user: @user %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   get 'surplus', to: 'surplus#grouped_index'
   get 'admin', to: 'admin_tools#show'
 
-  resources :users, only: [:index, :show, :destroy]
+  resources :users, except: [:edit, :update]
 
   resources :organizations, except: :new do
     resources :needs, only: [:index, :new, :create]

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe UsersController, type: :controller do
   # UsersController. Be sure to keep this updated too.
   let(:valid_session) { {} }
 
+  before(:each) { expect(controller).to receive(:authorize).and_return(true) }
+
   describe "GET #index" do
     it "returns a success response" do
       User.create! valid_attributes

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -34,6 +34,22 @@ RSpec.describe UsersController, type: :controller do
     end
   end
 
+  describe "POST #create" do
+    context "with valid params" do
+      it "creates a new user" do
+        expect {
+          post :create, params: {user: valid_attributes}, session: valid_session
+        }.to change(User, :count).by(1)
+      end
+    end
+    context "with invalid params" do
+      it "returns a success response (renders 'new' view)" do
+        post :create, params: {user: invalid_attributes}, session: valid_session
+        expect(response).to be_successful
+      end
+    end
+  end
+
   describe "DELETE #destroy" do
     it "destroys the requested user" do
       user = User.create! valid_attributes

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  let!(:superuser_role) { Role.create(name: 'superuser') }
+  let(:admin_role) { Role.create!(name: 'admin') }
+  let(:member_role) { Role.create!(name: 'member') }
+
+  let(:superuser) { create(:user, email: 'superuser@example.org') }
+  let(:admin) { create(:user, email: 'admin@example.org') }
+  let(:member) { create(:user, email: 'member@example.org') }
+  let(:user) { create(:user, email: 'user@example.org') }
+
+  let(:info_211) { create(:organization, name: '211 info') }
+  let(:jones_org) { create(:organization, name: 'jones org') }
+
   describe 'validations' do
     it { should validate_presence_of(:name) }
     it { should validate_uniqueness_of(:email).ignoring_case_sensitivity }
@@ -9,6 +21,63 @@ RSpec.describe User, type: :model do
   describe 'relationships' do
     it { should have_many(:memberships).dependent(:destroy) }
     it { should have_many(:roles).through(:memberships) }
-    it { should have_one(:organization).through(:memberships) }
+    it { should have_many(:organizations).through(:memberships) }
+  end
+
+  describe 'user roles' do
+    describe '#superuser?' do
+      it 'returns truthy when user is superuser' do
+        Membership.create(user_id: superuser.id, role_id: superuser_role.id)
+        expect(superuser).to be_superuser
+      end
+
+      it 'returns falsey when user is not an superuser' do
+        expect(admin).to_not be_superuser
+      end
+    end
+
+    describe '#admin?' do
+      it 'returns truthy when user is admin' do
+        Membership.create(user_id: admin.id, role_id: admin_role.id, organization_id: info_211.id)
+        expect(admin).to be_admin
+      end
+
+      it 'returns falsey when user is not an admin' do
+        expect(user).to_not be_admin
+      end
+    end
+
+    describe '#admin_for?' do
+      it 'returns truthy when user admin belongs to same organization as user' do
+        Membership.create(user_id: admin.id, role_id: admin_role.id, organization_id: info_211.id)
+        Membership.create(user_id: user.id, role_id: member_role.id, organization_id: info_211.id)
+        expect(admin).to be_admin_for user
+      end
+
+      it 'returns falsey when admin is not in the same organization as the user' do
+        Membership.create(user_id: admin.id, role_id: admin_role.id, organization_id: info_211.id)
+        Membership.create(user_id: user.id, role_id: member_role.id, organization_id: jones_org.id)
+        expect(admin).to_not be_admin_for user
+      end
+
+      it 'returns falsey when user is not a member of an organization' do
+        Membership.create(user_id: admin.id, role_id: admin_role.id, organization_id: info_211.id)
+        Membership.create(user_id: superuser.id, role_id: superuser_role.id)
+        expect(admin).to_not be_admin_for superuser
+      end
+
+      it 'returns falsey when user does not belong to an organization' do
+        Membership.create(user_id: user.id, role_id: member_role.id)
+        Membership.create(user_id: superuser.id, role_id: superuser_role.id)
+        expect(user).to_not be_admin_for superuser
+      end
+    end
+  end
+
+  describe '#organization' do
+    it 'returns a users organization' do
+      Membership.create(user_id: member.id, role_id: member_role.id, organization_id: info_211.id)
+      expect(member.organization).to eq(info_211)
+    end
   end
 end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -47,7 +47,20 @@ RSpec.describe UserPolicy, type: :policy do
   end
 
   permissions :show? do
-    pending "add some examples to (or delete) #{__FILE__}"
+    it 'grants access to your own show page' do
+      user = User.find(member.id)
+      expect(subject).to permit(member, user)
+    end
+
+    it 'grants access to other users show page' do
+      user = User.find(admin.id)
+      expect(subject).to permit(member, user)
+    end
+
+    it 'grants access to the superuser' do
+      Membership.create!(role_id: superuser_role.id, user_id: superuser.id)
+      expect(subject).to permit(superuser)
+    end
   end
 
   permissions :new?, :create? do

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+require 'pundit/rspec'
+
+RSpec.describe UserPolicy, type: :policy do
+  subject { described_class }
+
+  let(:superuser_role) { Role.create(name: 'superuser') }
+  let!(:superuser) { create(:user) }
+
+  permissions :show? do
+    pending "add some examples to (or delete) #{__FILE__}"
+  end
+
+  permissions :new?, :create? do
+    it 'grants access to the superuser' do
+      Membership.create(role_id: superuser_role.id, user_id: superuser.id)
+      expect(subject).to permit(superuser)
+    end
+  end
+end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -21,26 +21,12 @@ RSpec.describe UserPolicy, type: :policy do
       expect(subject).to permit(superuser)
     end
 
-    context 'admin' do
-      it 'grants access within their organization' do
-        Membership.create!(role_id: admin_role.id, user_id: admin.id, organization_id: info_211.id)
-        Membership.create!(role_id: member_role.id, user_id: member.id, organization_id: info_211.id)
-        expect(subject).to permit(admin, member)
-      end
-
-      it 'denies access outside of the organization' do
-        Membership.create!(role_id: admin_role.id, user_id: admin.id, organization_id: info_211.id)
-        Membership.create!(role_id: member_role.id, user_id: member.id, organization_id: jones_org.id)
-        expect(subject).to_not permit(admin, member)
-      end
+    it 'denies access to the admin' do
+      Membership.create!(role_id: admin_role.id, user_id: admin.id, organization_id: info_211.id)
+      expect(subject).to_not permit(admin)
     end
 
-    it 'denies access to the member' do
-      Membership.create!(role_id: member_role.id, user_id: member.id, organization_id: info_211.id)
-      expect(subject).to_not permit(member, member)
-    end
-
-    it 'does not grant access to member' do
+    it 'denies access to member' do
       Membership.create!(role_id: member_role.id, user_id: member.id, organization_id: info_211.id)
       expect(subject).to_not permit(member)
     end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -13,8 +13,18 @@ RSpec.describe UserPolicy, type: :policy do
 
   permissions :new?, :create? do
     it 'grants access to the superuser' do
-      Membership.create(role_id: superuser_role.id, user_id: superuser.id)
+      Membership.create!(role_id: superuser_role.id, user_id: superuser.id)
       expect(subject).to permit(superuser)
     end
+
+    it 'grants access to the admin' do
+      Membership.create!(role_id: admin_role.id, user_id: admin.id, organization_id: info_211.id)
+      expect(subject).to permit(admin)
+    end
+
+    it 'denies access to the member' do
+      expect(subject).to_not permit(member)
+    end
+  end
   end
 end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -78,5 +78,30 @@ RSpec.describe UserPolicy, type: :policy do
       expect(subject).to_not permit(member)
     end
   end
+
+  permissions :destroy? do
+    it 'grants access to the superuser' do
+      Membership.create!(role_id: superuser_role.id, user_id: superuser.id)
+      expect(subject).to permit(superuser)
+    end
+
+    context 'admin' do
+      it 'grants access within their organization' do
+        Membership.create!(role_id: admin_role.id, user_id: admin.id, organization_id: info_211.id)
+        Membership.create!(role_id: member_role.id, user_id: member.id, organization_id: info_211.id)
+        expect(subject).to permit(admin, member)
+      end
+
+      it 'denies access outside of the organization' do
+        Membership.create!(role_id: admin_role.id, user_id: admin.id, organization_id: info_211.id)
+        Membership.create!(role_id: member_role.id, user_id: member.id, organization_id: jones_org.id)
+        expect(subject).to_not permit(admin, member)
+      end
+    end
+
+    it 'denies access to the member' do
+      Membership.create!(role_id: member_role.id, user_id: member.id, organization_id: info_211.id)
+      expect(subject).to_not permit(member, member)
+    end
   end
 end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -4,8 +4,47 @@ require 'pundit/rspec'
 RSpec.describe UserPolicy, type: :policy do
   subject { described_class }
 
-  let(:superuser_role) { Role.create(name: 'superuser') }
-  let!(:superuser) { create(:user) }
+  let!(:superuser_role) { Role.create(name: 'superuser') }
+  let(:admin_role) { Role.create(name: 'admin') }
+  let(:member_role) { Role.create(name: 'member') }
+
+  let(:info_211) { Organization.create(name: '211_info') }
+  let(:jones_org)  {Organization.create(name: 'jones_org') }
+
+  let(:superuser) { create(:user, email: 'superuser@example.org') }
+  let(:admin) { create(:user, email: 'admin@example.org') }
+  let(:member) { create(:user, email: 'member@example.org') }
+
+  permissions :index? do
+    it 'grants access to the superuser' do
+      Membership.create!(role_id: superuser_role.id, user_id: superuser.id)
+      expect(subject).to permit(superuser)
+    end
+
+    context 'admin' do
+      it 'grants access within their organization' do
+        Membership.create!(role_id: admin_role.id, user_id: admin.id, organization_id: info_211.id)
+        Membership.create!(role_id: member_role.id, user_id: member.id, organization_id: info_211.id)
+        expect(subject).to permit(admin, member)
+      end
+
+      it 'denies access outside of the organization' do
+        Membership.create!(role_id: admin_role.id, user_id: admin.id, organization_id: info_211.id)
+        Membership.create!(role_id: member_role.id, user_id: member.id, organization_id: jones_org.id)
+        expect(subject).to_not permit(admin, member)
+      end
+    end
+
+    it 'denies access to the member' do
+      Membership.create!(role_id: member_role.id, user_id: member.id, organization_id: info_211.id)
+      expect(subject).to_not permit(member, member)
+    end
+
+    it 'does not grant access to member' do
+      Membership.create!(role_id: member_role.id, user_id: member.id, organization_id: info_211.id)
+      expect(subject).to_not permit(member)
+    end
+  end
 
   permissions :show? do
     pending "add some examples to (or delete) #{__FILE__}"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,6 +62,9 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # User sign_in method in request specs.
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,10 +1,29 @@
 require 'rails_helper'
 
 RSpec.describe "Users", type: :request do
+  let!(:superuser_role) { Role.create name: 'superuser' }
+  let!(:admin_role) { Role.create name: 'admin' }
+  let(:info_211) { create(:organization, name: '211 info') }
   describe "GET /users" do
-    it "works! (now write some real specs)" do
+    it "redirects when not authorized" do
+      get users_path
+      expect(response).to have_http_status(302)
+    end
+
+    it "is success when superuser" do
+      superuser = create(:user, email: 'superuser@example.org')
+      Membership.create(user_id: superuser.id, role_id: superuser_role.id)
+      sign_in superuser
       get users_path
       expect(response).to have_http_status(200)
+    end
+
+    it "redirects when admin" do
+      admin = create(:user, email: 'admin@example.org')
+      Membership.create(user_id: admin.id, role_id: admin_role.id, organization_id: info_211.id)
+      sign_in admin
+      get users_path
+      expect(response).to have_http_status(302)
     end
   end
 end

--- a/spec/views/users/new.html.erb_spec.rb
+++ b/spec/views/users/new.html.erb_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe "users/new", type: :view do
+  before(:each) do
+    assign(:user, build(:user))
+  end
+
+  it "renders new user form" do
+    render
+
+    assert_select "form[action=?][method=?]", users_path, "post" do
+
+      assert_select "input[name=?]", "user[name]"
+
+      assert_select "input[name=?]", "user[email]"
+
+      assert_select "input[name=?]", "user[password]"
+    end
+  end
+end


### PR DESCRIPTION
This PR does a few things:
1. Removed route allowing anyone to sign up as a user
2. Created link to sign up a user on the admin page
3. Created authorization policy for user resource
    - Superuser can index all users
    - Any user can view another users profile
    - Only superuser and admins can create new users
    - Superuser can delete any user. Admin can only delete users within their organization.

Fixes #72 