### PR TITLE
Create active query for needs/surplus index

### DIFF
--- a/app/controllers/needs_controller.rb
+++ b/app/controllers/needs_controller.rb
@@ -7,7 +7,10 @@ class NeedsController < ApplicationController
   end
 
   def grouped_index
-    @organizations = Organization.all.includes(:needs)
+    active = params.fetch(:active, true)
+    @organizations = Organization.all.includes(:needs).
+                                      where('needs.active = ?', active).
+                                      references(:needs)
   end
 
   def show

--- a/app/controllers/surplus_controller.rb
+++ b/app/controllers/surplus_controller.rb
@@ -7,7 +7,10 @@ class SurplusController < ApplicationController
   end
 
   def grouped_index
-    @organizations = Organization.all.includes(:surplus)
+    active = params.fetch(:active, true)
+    @organizations = Organization.all.includes(:surplus).
+                                      where('surplus.active = ?', active).
+                                      references(:surplus)
   end
 
   def show

--- a/app/views/needs/grouped_index.html.erb
+++ b/app/views/needs/grouped_index.html.erb
@@ -1,4 +1,6 @@
 <h1>Needs</h1>
+<%= link_to 'Active', { active: true } %>
+<%= link_to 'Inactive', { active: false }%>
 
 <% @organizations.each do |organization| %>
 <h2><%= organization.name %></h2>

--- a/app/views/surplus/grouped_index.html.erb
+++ b/app/views/surplus/grouped_index.html.erb
@@ -1,4 +1,6 @@
 <h1>Surplus</h1>
+<%= link_to 'Active', { active: true } %>
+<%= link_to 'Inactive', { active: false }%>
 
 <% @organizations.each do |organization| %>
 <h2><%= organization.name %></h2>

--- a/spec/requests/needs_spec.rb
+++ b/spec/requests/needs_spec.rb
@@ -10,10 +10,37 @@ RSpec.describe "Needs", type: :request do
   end
 
   describe 'Get /needs' do
-    let!(:needs) { [create(:need, resource: 'need_one'), create(:need, resource: 'need_two')] }
-    it 'lists all needs across all organizations' do
+    let!(:needs) { [create(:need, resource: 'need_one'),
+                    create(:need, resource: 'need_two'),
+                    create(:need, resource: 'need_three', active: false)] }
+    it 'default view lists active needs across all organizations' do
       get needs_path
       expect(response.body).to include('need_one', 'need_two')
+    end
+
+    it 'default view does not list inactive needs' do
+      get needs_path
+      expect(response.body).to_not include('need_three')
+    end
+
+    it 'lists active needs with active query set to true' do
+      get needs_path, params: { active: true }
+      expect(response.body).to include('need_one', 'need_two')
+    end
+
+    it 'does not list inactive needs with active query set to true' do
+      get needs_path, params: { active: true }
+      expect(response.body).to_not include('need_three')
+    end
+
+    it 'lists inactive needs with active query set to false' do
+      get needs_path, params: { active: false }
+      expect(response.body).to include('need_three')
+    end
+
+    it 'does not list active needs with active query set to false' do
+      get needs_path, params: { active: false }
+      expect(response.body).to_not include('need_one', 'need_two')
     end
   end
 end

--- a/spec/requests/surplus_spec.rb
+++ b/spec/requests/surplus_spec.rb
@@ -10,10 +10,37 @@ RSpec.describe "Surplus", type: :request do
   end
 
   describe "GET /surplus" do
-    let!(:surplus) { [create(:surplus, resource: 'surplus_one'), create(:surplus, resource: 'surplus_two')] }
-    it "lists all organizations surplus" do
+    let!(:surplus) { [create(:surplus, resource: 'surplus_one'),
+                      create(:surplus, resource: 'surplus_two'),
+                      create(:surplus, resource: 'surplus_three', active: false)] }
+    it "default view lists active surplus across all organizations" do
       get surplus_path
       expect(response.body).to include('surplus_one', 'surplus_two')
+    end
+
+    it 'default view does not list inactive surplus' do
+      get surplus_path
+      expect(response.body).to_not include('surplus_three')
+    end
+
+    it 'lists active surplus with active query set to true' do
+      get surplus_path, params: { active: true }
+      expect(response.body).to include('surplus_one', 'surplus_two')
+    end
+
+    it 'does not list inactive surplus with active query set to true' do
+      get surplus_path, params: { active: true }
+      expect(response.body).to_not include('surplus_three')
+    end
+
+    it 'lists inactive surplus with active query set to false' do
+      get surplus_path, params: { active: false }
+      expect(response.body).to include('surplus_three')
+    end
+
+    it 'does not list active surplus with active query set to false' do
+      get surplus_path, params: { active: false }
+      expect(response.body).to_not include('surplus_one', 'surplus_two')
     end
   end
 end


### PR DESCRIPTION
Updated controller and added links to view active and inactive needs/surplus on the `grouped_index` view.
To view Active surplus:
`/surplus`
`/surplus?active=true`
To view Inactive surplus:
`/surplus?active=false`

And the same goes for needs. substituting surplus with needs.

Fixes #80 