### PR TITLE
Update membership validations

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -5,7 +5,7 @@ class Membership < ApplicationRecord
 
   validates :organization, presence: true, unless: :superuser?
   validates :user, uniqueness: { scope: :role }
-  validate :single_role, unless: :superuser?
+  validate :single_role
 
   private
 
@@ -18,9 +18,9 @@ class Membership < ApplicationRecord
     end
 
     def single_role
-      user = User.find(user_id)
-      if user.roles.any? { |role| role.name == 'admin' || role.name == 'member' }
-        errors.add(:user, "can't be an admin and member")
+      user = User.find_by(id: user_id)
+      if user && user.memberships.any?
+        errors.add(:user, "A role is already assigned")
       end
     end
 

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -3,7 +3,6 @@ class Membership < ApplicationRecord
   belongs_to :user
   belongs_to :organization, required: false
 
-  validates :organization, absence: true, if: :superuser?
   validates :organization, presence: true, unless: :superuser?
   validates :user, uniqueness: { scope: :role }
   validate :single_role, unless: :superuser?

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe Membership, type: :model do
         expect(record).to be_valid
       end
 
-      it 'denies validation when superuser is being assigned to an organization' do
+      it 'allows superuser to be assigned to an organization' do
         record = Membership.new(user_id: superuser.id, role_id: superuser_role.id, organization_id: organization.id)
-        expect(record).to_not be_valid
+        expect(record).to be_valid
       end
 
       it 'does not allow admin to be valid without an organization' do

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -45,16 +45,16 @@ RSpec.describe Membership, type: :model do
         expect(record).to_not be_valid
       end
 
-      it 'allows superuser to be an admin' do
+      it 'does not allow superuser to be an admin' do
         Membership.create(user_id: superuser.id, role_id: superuser_role.id)
         record = Membership.new(user_id: superuser.id, role_id: admin_role.id, organization_id: organization.id)
-        expect(record).to be_valid
+        expect(record).to_not be_valid
       end
 
-      it 'allows superuser to be a member' do
+      it 'does not allow superuser to be a member' do
         Membership.create(user_id: superuser.id, role_id: superuser_role.id)
-        record = Membership.new(user_id: member.id, role_id: member_role.id, organization_id: organization.id)
-        expect(record).to be_valid
+        record = Membership.new(user_id: superuser.id, role_id: member_role.id, organization_id: organization.id)
+        expect(record).to_not be_valid
       end
 
       it 'does not allow a user to be a member of another organization' do


### PR DESCRIPTION
Allowed superuser to be assigned to an organization, and disabled the ability for superuser to take on the admin role.

This is done to enforce the one role per user rule.

Fixes #86 