### PR TITLE
Create user and membership simultaneously

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,6 +17,7 @@ class UsersController < ApplicationController
 
   def create
     @user = User.new(user_params)
+    @user.memberships.new(membership_params)
     authorize @user
 
     respond_to do |format|
@@ -47,6 +48,18 @@ class UsersController < ApplicationController
     # Never trust parameters from the scary internet, only allow the white list through.
     def user_params
       params.require(:user).permit(:name, :email, :password)
+    end
+
+    def membership_params
+      { role: role_param, organization: organization_param }
+    end
+
+    def role_param
+      Role.find_by(name: params.fetch(:role, {})[:name])
+    end
+
+    def organization_param
+      Organization.find_by(id: params[:organization][:id])
     end
 
     def authorize_user

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -14,7 +14,7 @@ class Membership < ApplicationRecord
     end
 
     def superuser?
-      role_id == superuser_role.id
+      superuser_role && role_id == superuser_role.id
     end
 
     def single_role

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -26,6 +26,29 @@
     <%= form.password_field :password %>
   </div>
 
+  <div class="field">
+    <%= label :organization, :id, "Organization" %>
+    <% if current_user.superuser? %>
+      <%= collection_select :organization, :id, Organization.all, :id, :name,
+                            include_blank: true,
+                            selected: current_user.organization&.id %>
+    <% else %>
+      <%= hidden_field :organization, :id, value: current_user.organization&.id %>
+      <%= link_to current_user.organization&.name, current_user.organization %>
+    <% end %>
+  </div>
+
+  <div class="field">
+    <% if current_user.superuser? %>
+      <%= radio_button :role, :name, :superuser %>
+      <%= label :role, :name, "Superuser" %>
+    <% end %>
+    <%= radio_button :role, :name, :admin %>
+    <%= label :role, :name, "Admin" %>
+    <%= radio_button :role, :name, :member %>
+    <%= label :role, :name, "Member" %>
+  </div>
+
   <div class="actions">
     <%= form.submit %>
   </div>

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe UsersController, type: :controller do
     attributes_for(:user)
   }
 
+  let(:role) { create(:role) }
+
+  let(:organization) { create(:organization) }
+
   let(:invalid_attributes) {
     { email: 'invalid_email' }
   }
@@ -40,13 +44,14 @@ RSpec.describe UsersController, type: :controller do
     context "with valid params" do
       it "creates a new user" do
         expect {
-          post :create, params: {user: valid_attributes}, session: valid_session
-        }.to change(User, :count).by(1)
+          post :create, params: { user: valid_attributes, role: { name: role.name }, organization: { id: organization.id } }, session: valid_session
+        }.to change(User,       :count).by(1).
+         and change(Membership, :count).by(1)
       end
     end
     context "with invalid params" do
       it "returns a success response (renders 'new' view)" do
-        post :create, params: {user: invalid_attributes}, session: valid_session
+        post :create, params: { user: invalid_attributes, role: { name: role.name }, organization: { id: organization.id } }, session: valid_session
         expect(response).to be_successful
       end
     end

--- a/spec/views/users/new.html.erb_spec.rb
+++ b/spec/views/users/new.html.erb_spec.rb
@@ -5,16 +5,55 @@ RSpec.describe "users/new", type: :view do
     assign(:user, build(:user))
   end
 
-  it "renders new user form" do
-    render
+  context "superuser" do
+    it "renders new user form" do
+      super_user = create(:user, email: 'superuser@email.org')
+      super_user.memberships.create role: create(:role, name: 'superuser')
+      allow(view).to receive(:current_user).and_return(super_user)
 
-    assert_select "form[action=?][method=?]", users_path, "post" do
+      render
 
-      assert_select "input[name=?]", "user[name]"
+      assert_select "form[action=?][method=?]", users_path, "post" do
 
-      assert_select "input[name=?]", "user[email]"
+        assert_select "input[name=?]", "user[name]"
 
-      assert_select "input[name=?]", "user[password]"
+        assert_select "input[name=?]", "user[email]"
+
+        assert_select "input[name=?]", "user[password]"
+
+        assert_select "select[name=?]", "organization[id]"
+
+        assert_select "input[type=?]", "radio"
+        assert_select "input[id=?]", "role_name_superuser"
+        assert_select "input[id=?]", "role_name_admin"
+        assert_select "input[id=?]", "role_name_member"
+      end
+    end
+  end
+
+  context "admin" do
+    it "renders new user form" do
+      admin_user = create(:user, email: 'adminuser@email.org')
+      admin_user.memberships.create role: create(:role, name: 'adminuser')
+      allow(view).to receive(:current_user).and_return(admin_user)
+
+      render
+
+      assert_select "form[action=?][method=?]", users_path, "post" do
+
+        assert_select "input[name=?]", "user[name]"
+
+        assert_select "input[name=?]", "user[email]"
+
+        assert_select "input[name=?]", "user[password]"
+
+        assert_select "select[name=?]", "organization[id]", false
+
+        assert_select "input[type=?]", "radio"
+        assert_select "input[id=?]", "role_name_superuser", false
+        assert_select "input[id=?]", "role_name_admin"
+        assert_select "input[id=?]", "role_name_member"
+      end
     end
   end
 end


### PR DESCRIPTION
This PR creates user membership during user creation.
The add user view was updated to include membership fields.
When a superuser is logged in, it displays a select box for the organization field. If the superuser belongs to an organization, then the select box defaults to that organization; otherwise, it defaults to null. When an admin is logged in, the select box does not appear and displays the admin's organization.
For role selection, the admin needs to select either member or admin, and when the superuser is logged in, they have all the admin role options plus the superuser option visible.

Resolves #92 , and partially resolves issue #87 

Superuser view:
<img width="301" alt="Screenshot 2019-11-07 21 04 20" src="https://user-images.githubusercontent.com/19519317/68451075-32fd1d00-01a2-11ea-9e47-886e87010963.png">

Admin view:
<img width="293" alt="Screenshot 2019-11-07 21 05 25" src="https://user-images.githubusercontent.com/19519317/68451112-56c06300-01a2-11ea-8be1-a89afcd90057.png">