### PR TITLE
Allow admin access to admin tools

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -14,7 +14,7 @@ class Membership < ApplicationRecord
     end
 
     def superuser?
-      role_id == superuser_role.id
+      superuser_role && role_id == superuser_role.id
     end
 
     def single_role

--- a/app/policies/admin_tool_policy.rb
+++ b/app/policies/admin_tool_policy.rb
@@ -1,6 +1,6 @@
 class AdminToolPolicy < Struct.new(:user, :AdminTool)
   def show?
     raise Pundit::NotAuthorizedError, "must be logged in" unless user
-    user.superuser?
+    user.superuser? || user.admin?
   end
 end

--- a/app/views/admin_tools/show.html.erb
+++ b/app/views/admin_tools/show.html.erb
@@ -4,8 +4,10 @@
 
 <%= link_to 'Add User', new_user_path, class: "link hover-blue dib pa2" %>
 
-<h2>New Organization</h2>
+<% if current_user.superuser? %>
+  <h2>New Organization</h2>
 
-<%= render 'organizations/form', organization: @organization %>
+  <%= render 'organizations/form', organization: @organization %>
+<% end %>
 
 <%= link_to "Show All", organizations_path, class: "link hover-blue dib pa2" %>

--- a/spec/policies/admin_tool_policy_spec.rb
+++ b/spec/policies/admin_tool_policy_spec.rb
@@ -4,21 +4,30 @@ require 'pundit/rspec'
 RSpec.describe AdminToolPolicy, type: :policy do
   subject { described_class }
 
-  let(:superuser_role) { Role.create(name: 'superuser') }
+  let!(:superuser_role) { Role.create(name: 'superuser') }
+  let(:admin_role) { Role.create(name: 'admin') }
+  let(:member_role) { Role.create(name: 'member') }
 
   let(:organization) { create(:organization) }
 
   let(:superuser) { create(:user) }
-  let(:user) { create(:user, email: 'user_email@example.org') }
+  let(:admin) { create(:user, email: 'admin_email@example.org') }
+  let(:member) { create(:user, email: 'member_email@example.org') }
 
   permissions :show? do
     it 'grants access to the superuser' do
-      Membership.create(role_id: superuser_role.id, user_id: superuser.id)
+      superuser.memberships.create(role_id: superuser_role.id)
       expect(subject).to permit(superuser, organization)
     end
 
-    it 'denies acces when not a superuser' do
-      expect(subject).to_not permit(user, organization)
+    it 'grants access to the admin' do
+      admin.memberships.create(role_id: admin_role.id, organization_id: organization.id)
+      expect(subject).to permit(admin, organization)
+    end
+
+    it 'denies access to the member' do
+      member.memberships.create(role_id: member_role.id, organization_id: organization.id)
+      expect(subject).to_not permit(member, organization)
     end
   end
 end

--- a/spec/views/admin_tools/show.html.erb_spec.rb
+++ b/spec/views/admin_tools/show.html.erb_spec.rb
@@ -1,5 +1,40 @@
 require 'rails_helper'
 
-RSpec.describe "admin_tools/index.html.erb", type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
+RSpec.describe "admin_tools/show.html.erb", type: :view do
+  describe 'superuser' do
+    before(:each) do
+      superuser = create(:user)
+      superuser.memberships.create(role: create(:role, name: 'superuser'))
+      assign(:organization, build(:organization))
+      allow(view).to receive(:current_user).and_return(superuser)
+    end
+
+    it 'renders the add user link' do
+      render
+      expect(rendered).to match(new_user_path)
+    end
+
+    it 'renders the organization form' do
+      render
+      expect(rendered).to match('form action="/organizations"')
+    end
+  end
+
+  describe 'admin' do
+    before(:each) do
+      admin = create(:user)
+      admin.memberships.create(role: create(:role, name: 'admin'))
+      allow(view).to receive(:current_user).and_return(admin)
+    end
+
+    it 'renders the add user link' do
+      render
+      expect(rendered).to match(new_user_path)
+    end
+
+    it 'does not render the organization form' do
+      render
+      expect(rendered).to_not match('form action="/organizations"')
+    end
+  end
 end


### PR DESCRIPTION
Updated the AdminTool policy to allow admin access, and updated the view page as follows:

When an admin is logged in, the add user link is available; otherwise, a superuser is logged in, and they additionally have access to the create organization form.

Resolves #95 